### PR TITLE
Fix syntax highlighting within class attribute and function parameter initializers

### DIFF
--- a/TypeScript.JSON-tmLanguage
+++ b/TypeScript.JSON-tmLanguage
@@ -249,7 +249,7 @@
       "begin": "\\b([a-zA-Z_$][\\w$]*)\\s*(?=(=|:))",
       "end": "(;)",
       "beginCaptures": {
-        "1": { "name": "variable.ts" }
+        "1": { "name": "meta.toc-list.class.member.ts" }
       },
       "endCaptures": {
         "1": { "name": "punctuation.terminator.statement.ts" }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -385,7 +385,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>variable.ts</string>
+					<string>meta.toc-list.class.member.ts</string>
 				</dict>
 			</dict>
 			<key>end</key>


### PR DESCRIPTION
Hi, i've made few aditional fixes.

It fixes use cases like this:

``` typescript
class MyClass {
  attr = initfn('string arg');
  someMethod(arg: number[] = [1,2,3]) { }
}
```
