### PR TITLE
keymap command calls fix, context menu and README update

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -1,10 +1,8 @@
 [
-	{"keys": ["alt+shift+s"], "command": "check_syntax"}
-,	{"keys": ["alt+shift+r"], "command": "run_script"}
-,	{"keys": ["alt+shift+c"], "command": "compile"}
-,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
-,	{"keys": ["alt+shift+l"], "command": "compile_and_display", "args": {"opt": "-t"}}
-,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
-,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+	{"keys": ["alt+shift+s"], "command": "check_code_syntax"}
+,	{"keys": ["alt+shift+c"], "command": "compile_code"}
+,	{"keys": ["alt+shift+d"], "command": "compile_and_display_code", "args": {"opt": "-p"}}
+,	{"keys": ["alt+shift+l"], "command": "compile_and_display_code", "args": {"opt": "-t"}}
+,	{"keys": ["alt+shift+n"], "command": "compile_and_display_code", "args": {"opt": "-n"}}
+,	{"keys": ["alt+shift+w"], "command": "toggle_watch_mode"}
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -1,10 +1,8 @@
 [
-	{"keys": ["alt+shift+s"], "command": "check_syntax"}
-,	{"keys": ["alt+shift+r"], "command": "run_script"}
-,	{"keys": ["alt+shift+c"], "command": "compile"}
-,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
-,	{"keys": ["alt+shift+x"], "command": "compile_and_display", "args": {"opt": "-t"}}
-,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
-,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+	{"keys": ["alt+shift+s"], "command": "check_code_syntax"}
+,	{"keys": ["alt+shift+c"], "command": "compile_code"}
+,	{"keys": ["alt+shift+d"], "command": "compile_and_display_code", "args": {"opt": "-p"}}
+,	{"keys": ["alt+shift+x"], "command": "compile_and_display_code", "args": {"opt": "-t"}}
+,	{"keys": ["alt+shift+n"], "command": "compile_and_display_code", "args": {"opt": "-n"}}
+,	{"keys": ["alt+shift+w"], "command": "toggle_watch_mode"}
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -1,10 +1,8 @@
 [
-	{"keys": ["alt+shift+s"], "command": "check_syntax"}
-,	{"keys": ["alt+shift+r"], "command": "run_script"}
-,	{"keys": ["alt+shift+c"], "command": "compile"}
-,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
-,	{"keys": ["alt+shift+l"], "command": "compile_and_display", "args": {"opt": "-t"}}
-,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
-,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+	{"keys": ["alt+shift+s"], "command": "check_code_syntax"}
+,	{"keys": ["alt+shift+c"], "command": "compile_code"}
+,	{"keys": ["alt+shift+d"], "command": "compile_and_display_code", "args": {"opt": "-p"}}
+,	{"keys": ["alt+shift+l"], "command": "compile_and_display_code", "args": {"opt": "-t"}}
+,	{"keys": ["alt+shift+n"], "command": "compile_and_display_code", "args": {"opt": "-n"}}
+,	{"keys": ["alt+shift+w"], "command": "toggle_watch_mode"}
 ]

--- a/Menu/Context.sublime-menu
+++ b/Menu/Context.sublime-menu
@@ -1,6 +1,26 @@
 [
-    {
-      "command": "run_script",
-      "caption": "Run Script / Selection"
-    }
+  {
+    "caption": "Better TypeScript",
+    "children": [
+      {
+        "caption": "Check Syntax",
+        "command": "check_code_syntax"
+      },
+      {
+        "caption": "Compile File",
+        "command": "compile_code"
+      },
+      {
+        "caption": "Compile and Display JavaScript",
+        "command": "compile_and_display_code",
+        "args": {
+          "opt": "-p"
+        }
+      },
+      {
+        "caption": "Toggle Watch Mode",
+        "command": "toggle_watch_mode"
+      }
+    ]
+  }
 ]

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Current package don't have sublime build file. You can create it by yourself and
 
 ```
 {
-    "cmd": ["tsc","$file", "-m", "amd", "--sourceMap"],
+    "cmd": ["tsc", "-d", "-m", "amd", "--sourcemap", "$file"],
     "file_regex": "(.*\\.ts?)\\s\\(([0-9]+)\\,([0-9]+)\\)\\:\\s(...*?)$",
     "selector": "source.ts",
     "osx": {
        "path": "/usr/local/bin:/opt/local/bin"
     },
     "windows": {
-        "cmd": ["tsc.cmd", "$file", "-m", "amd"]
+        "cmd": ["tsc.cmd", "-d", "-m", "amd", "--sourcemap", "$file"]
     }
 }
 ```
@@ -44,7 +44,6 @@ You can access the commands either using the command palette (`ctrl+shift+P` or 
 	alt+shift+c - Compile a file
 	alt+shift+d - Display compiled JavaScript
 	alt+shift+w - Toggle watch mode
-	alt+shift+p - Toggle output panel
 
 
 Context menu has `Compile Output` that compiles the current TypeScript and outputs the javascript code that is run, in a panel.

--- a/TypeScript.py
+++ b/TypeScript.py
@@ -442,7 +442,7 @@ class Watcher():
             })
 
 
-class ToggleWatchMode(TextCommand):
+class ToggleWatchModeCommand(TextCommand):
     views = {}
     outputs = {}
 


### PR DESCRIPTION
Updated Keymaps commands to correct names as per TypeScript.py file
Removed seemingly unused Keymaps commands i.e. 'run_script' and 'toggle_output_panel'
Updated Context options to match those available in the Command Pallet
Updated README.md so '$file' at the end of cmd array and included '-d' flag on example build file
